### PR TITLE
Add a rake task to generate newsletter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 *.html
+*.zip

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,8 @@ desc "Generate HTML from Trello board"
 task :generate do
   TrelloNewsletter.new.generate
 end
+
+desc "Create new mailchimp campaign from HTML and CSS zip folder"
+task :create_campaign do
+  TrelloNewsletter.new.export_to_mailchimp
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 require "bundler/gem_tasks"
+require_relative "lib/trello_newsletter"
 
+# http://bundler.io/bundler_setup.html
+Bundler.setup
+
+desc "Generate HTML from Trello board"
+task :generate do
+  TrelloNewsletter.new.generate
+end

--- a/lib/trello_newsletter.rb
+++ b/lib/trello_newsletter.rb
@@ -10,38 +10,44 @@ Trello.configure do |config|
 end
 
 class TrelloNewsletter
-  boards = Trello::Board.all
-  puts boards.count
-  board_name = "CodeNewbie Newsletter"
-  board = Trello::Board.all.find { |b| b.name == board_name }
-  lists = board.lists
+  def generate
+    boards = Trello::Board.all
+    puts boards.count
+    board_name = "CodeNewbie Newsletter"
+    board = Trello::Board.all.find { |b| b.name == board_name }
+    lists = board.lists
 
-  meta_list = lists.select { |n| n.attributes[:name] == "Meta" }.first
-  meta = Meta.new(meta_list)
+    meta_list = lists.select { |n| n.attributes[:name] == "Meta" }.first
+    meta = Meta.new(meta_list)
 
-  headlines_list = lists.select { |n| n.attributes[:name] == "Headlines" }.first
-  template = File.open("index.html", "w")
-  template.puts <<-DOC.gsub(/^ {4}/, '')
-  <!DOCTYPE html>
-  <html>
-    <head>
-      <meta charset="utf-8">
-    </head>
-    <body>
-      <img src=#{meta.header_image} alt="Header Image">
-      <p>Published at: #{meta.published_at}</p>
-      <p>#{meta.intro_text}</p>
-  DOC
-  headlines_list.cards.each do |card|
-    post = Post.new(card)
-    template.puts "   <div>"
-    template.puts "    <h2>#{post.title}</h2>"
-    template.puts "    #{post.body}"
-    template.puts "   </div>"
+    headlines_list = lists.select { |n| n.attributes[:name] == "Headlines" }.first
+    html_output(meta, headlines_list)
+    puts "Finished generating issue"
   end
-  template.puts "<p>#{meta.outro_text}</p>"
-  template.puts "FINISHED!"
-  template.close
-  puts "Finished generating issue"
+
+  def html_output(meta, headlines_list)
+    template = File.open("index.html", "w")
+    template.puts <<-DOC.gsub(/^ {4}/, '')
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+      </head>
+      <body>
+        <img src=#{meta.header_image} alt="Header Image">
+        <p>Published at: #{meta.published_at}</p>
+        <p>#{meta.intro_text}</p>
+    DOC
+    headlines_list.cards.each do |card|
+      post = Post.new(card)
+      template.puts "   <div>"
+      template.puts "    <h2>#{post.title}</h2>"
+      template.puts "    #{post.body}"
+      template.puts "   </div>"
+    end
+    template.puts "<p>#{meta.outro_text}</p>"
+    template.puts "FINISHED!"
+    template.close
+  end
 end
 

--- a/lib/trello_newsletter.rb
+++ b/lib/trello_newsletter.rb
@@ -2,6 +2,7 @@ require_relative "trello_newsletter/version"
 require_relative "meta.rb"
 require_relative "post.rb"
 require "trello"
+require "mailchimp"
 require "pry"
 
 Trello.configure do |config|
@@ -49,5 +50,20 @@ class TrelloNewsletter
     template.puts "FINISHED!"
     template.close
   end
-end
 
+  # https://apidocs.mailchimp.com/api/2.0/campaigns/create.php
+  # https://apidocs.mailchimp.com/api/2.0/lists/list.php
+  def export_to_mailchimp
+    mailchimp = Mailchimp::API.new(MAILCHIMP-API-KEY)
+    all_lists = mailchimp.lists.list
+    from_website_list = all_lists.select { |n| n.attributes['data']['name'] == "From Website" }
+    # Zip index.html and css
+    # create new mailchimp campaign and import the zip folder to it.
+    # Line 1539 in Mailchimp api gem source code
+    # Everything in the tracking option defaults to true except text clicks.
+    mailchimp.campaigns.create("regular", {list_id: from_website_list, subject: "Subject line", 
+                                           from_email: "hello@codenewbie.org", from_name: "#CodeNewbie", to_name: "*|FNAME|*",
+                                            tracking: {text_clicks: true}},
+                                           {archive: "archive name", archive_type: "zip"})
+  end 
+end

--- a/trello_newsletter.gemspec
+++ b/trello_newsletter.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "ruby-trello", "~> 1.2"
   spec.add_development_dependency "maruku", "~> 0.7.2"
+  spec.add_development_dependency "mailchimp-api", "~>2.0"
 end

--- a/trello_newsletter.gemspec
+++ b/trello_newsletter.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "ruby-trello", "~> 1.1"
+  spec.add_development_dependency "ruby-trello", "~> 1.2"
   spec.add_development_dependency "maruku", "~> 0.7.2"
 end


### PR DESCRIPTION
Write a rake task that generates the index.html of the newsletter.

Other changes:
- Bump ruby-trello gem version in the gemspec.
- Move the spaghetti code in TrelloNewsletter class into methods.
